### PR TITLE
Add documentation, example env, and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+SUPABASE_URL=your_supabase_url
+SUPABASE_KEY=your_supabase_key
+GEMINI_API_KEY=your_gemini_api_key
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# OliverAI_Enhanced
+# OliverAI Enhanced
+
+This project provides a minimal FastAPI backend.
+
+## Setup
+
+Install dependencies with wheels (offline):
+
+```bash
+pip install --no-index --find-links /path/to/wheelhouse -r requirements.txt
+```
+
+## Configuration
+
+Copy `.env.example` to `.env` and fill in your credentials:
+
+```bash
+cp .env.example .env
+```
+
+The environment variables are:
+
+- `SUPABASE_URL`
+- `SUPABASE_KEY`
+- `GEMINI_API_KEY`
+
+## Running the server
+
+```bash
+uvicorn ai_backend.app.main:app --reload
+```
+
+## Testing
+
+```bash
+pytest
+```
+
+

--- a/ai_backend/app/__init__.py
+++ b/ai_backend/app/__init__.py
@@ -1,0 +1,2 @@
+from .main import app
+__all__ = ["app"]

--- a/ai_backend/app/main.py
+++ b/ai_backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="AI Backend")
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}

--- a/ai_backend/config.py
+++ b/ai_backend/config.py
@@ -1,0 +1,11 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    supabase_url: str
+    supabase_key: str
+    gemini_api_key: str
+
+    class Config:
+        env_file = '.env'
+
+settings = Settings()

--- a/ai_backend/tests/test_health.py
+++ b/ai_backend/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from ai_backend.app.main import app
+
+client = TestClient(app)
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+supabase-py
+pydantic
+google-generativeai


### PR DESCRIPTION
## Summary
- document setup and offline installation
- provide `.env.example` with required variables
- trim unused import from `main.py`
- add pytest test for the health endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684cded1cf2c8333b2d8d8bf43869194