### PR TITLE
Add Gemini demo and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,66 @@
 # OliverAI Enhanced
 
-This repository contains the AI backend implementation focused on Google's Gemini models.
+This repository contains a lightweight AI backend powered by Google's Gemini models.
+It exposes a FastAPI application for retrieval–augmented generation (RAG) and includes
+a small script for directly calling the Gemini API.
 
 ## Structure
 
 - `ai_backend/` - FastAPI application for RAG operations powered by Gemini and Supabase Vector.
 - `.env.example` - Example environment variables required to run the backend.
+- `scripts/gemini_demo.py` – Simple script that calls the Gemini API using your key.
 
 Copy `.env.example` to `.env` and fill in your credentials before starting the
 server.
 
-## Usage
+## Setup
 
-Install dependencies and run the server. If the environment does not have
-internet access, pre-download the required wheels on another machine and copy
-them to a local directory (`wheelhouse`). Then run:
+1. Clone this repository and install the required Python packages. If your
+   environment does not have internet access, download the wheels on another
+   machine and place them in a `wheelhouse` directory first.
 
 ```bash
 pip install --no-index --find-links wheelhouse -r ai_backend/requirements.txt
+```
+
+2. Copy `.env.example` to `.env` and fill in the following values:
+
+```bash
+GEMINI_API_KEY=your_gemini_key
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_KEY=your-supabase-service-key
+```
+
+The clients are configured to use REST transport by default, which avoids common
+TLS issues when running behind proxies.
+
+## Running the server
+
+Start the FastAPI application with Uvicorn:
+
+```bash
 uvicorn ai_backend.app.main:app --reload
 ```
 
-The `wheelhouse` directory should contain wheel files for all dependencies.
-Generate it on a machine with internet access using:
+The server exposes endpoints for document processing and question answering.
+
+If you need to generate the wheelhouse directory on a machine with internet
+access, run:
 
 ```bash
 pip download -d wheelhouse -r ai_backend/requirements.txt
 ```
+
+## Running the demo script
+
+After configuring your API key you can test direct Gemini access:
+
+```bash
+export GEMINI_API_KEY=your_gemini_key
+python scripts/gemini_demo.py
+```
+
+It should print a short greeting returned by the model.
 
 
 ## Testing

--- a/ai_backend/embedding/gemini_embedding_client.py
+++ b/ai_backend/embedding/gemini_embedding_client.py
@@ -7,11 +7,11 @@ except ImportError:  # pragma: no cover - if package not installed
 
 
 class GeminiEmbeddingClient:
-    def __init__(self, api_key: str, model: str = "models/embedding-001"):
+    def __init__(self, api_key: str, model: str = "models/embedding-001", transport: str = "rest"):
         self.api_key = api_key
         self.model = model
         if genai is not None:
-            genai.configure(api_key=api_key)
+            genai.configure(api_key=api_key, transport=transport)
 
     async def embed_documents(self, texts: List[str]) -> List[List[float]]:
         if genai is None:

--- a/ai_backend/llm_clients/gemini_client.py
+++ b/ai_backend/llm_clients/gemini_client.py
@@ -5,11 +5,11 @@ except ImportError:  # pragma: no cover - if package not installed
 
 
 class GeminiClient:
-    def __init__(self, api_key: str, model: str = "gemini-pro"):
+    def __init__(self, api_key: str, model: str = "gemini-pro", transport: str = "rest"):
         self.api_key = api_key
         self.model_name = model
         if genai is not None:
-            genai.configure(api_key=api_key)
+            genai.configure(api_key=api_key, transport=transport)
             self.model = genai.GenerativeModel(model)
 
     async def generate(self, question: str, context: str) -> str:

--- a/scripts/gemini_demo.py
+++ b/scripts/gemini_demo.py
@@ -1,0 +1,16 @@
+import os
+import google.generativeai as genai
+
+
+def main() -> None:
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError("GEMINI_API_KEY environment variable not set")
+    genai.configure(api_key=api_key, transport="rest")
+    model = genai.GenerativeModel("models/gemini-1.5-flash-latest")
+    response = model.generate_content("Say hello")
+    print(response.text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- default Gemini clients to REST transport to avoid gRPC proxy issues
- add a simple `scripts/gemini_demo.py` for testing API connectivity
- document setup, running the server and demo script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf58337e883338d600b365ea8b2cf